### PR TITLE
Stealing Expansion

### DIFF
--- a/steal.lic
+++ b/steal.lic
@@ -17,8 +17,12 @@ class Steal
     bput('exp thievery', 'EXP HELP') if DRSkill.getrank('Thievery').zero?
 
     UserVars.stealing_timers ||= {}
-
-    @stealing_options = get_data('stealing').stealing_options.reject { |target| settings.dont_steal_list.include?(target['id'].to_i) }
+	@town_data = get_data('town')
+    @hometown = @town_data[settings.hometown]
+	@steal_town = settings.hometown
+    @stealing_options = get_data('stealing').stealing_options
+	  .reject { |target| settings.dont_steal_list.include?(target['id'].to_i) }
+	  .select { |target| @steal_town == (target['steal_town'])}
     @stealing_bag = settings.stealing_bag
     @bin_stolen = settings.bin_stolen
     @hide_to_steal = settings.hide_to_steal
@@ -26,10 +30,9 @@ class Steal
     @stealing_high_acceptable_count = settings.stealing_high_acceptable_count
     @steal_past_mindlock = settings.steal_past_mindlock
     @slow_bin_speed = settings.slow_bin_speed
-
     @difficulty_keys = %w(exceptionally very rather acceptable poorly vpoorly nearly trivial)
-
     @bin_items = []
+	@new_grab = false
   end
 
   def initialize
@@ -37,7 +40,7 @@ class Steal
       [],
       [
         { name: 'item', regex: /\w+|\w+\s\w+/, variable: true, description: 'item to steal' },
-        { name: 'container', regex: /.+/i, variable: true, description: 'Where the item is to steal e.g in catalog, on counter' }
+        { name: 'container', regex: /.+/i, variable: true, description: 'Where the item is to steal e.g "in catalog", "on counter"' }
       ]
     ]
 
@@ -45,6 +48,15 @@ class Steal
 
     settings = get_settings
     setup(settings)
+	
+	# Prevents multiple stealing and binning while building new targets
+	if args.item != nil
+	  @new_grab = true
+      @stealing_low_acceptable_count = 1
+      @stealing_high_acceptable_count = 1
+	  @bin_stolen = false
+	end
+	
 
     targets = find_targets(args.item, args.container)
     npcs = settings.npc_stealing_attempt_count > 0 ? find_npcs : []
@@ -114,15 +126,13 @@ class Steal
   def bin_items
     return if @bin_items.empty?
 
-    walk_to 6017
-    move('tap knocker')
-    move('north')
+    walk_to @hometown['bin_location']['id']
 
     stow_hands
     @bin_items.each do |item|
-      if @slow_bin_speed
+      if @slow_bin_speed 
         bput("get #{item} from my #{@stealing_bag}", 'You get')
-        bput("put #{item} in bin", 'nods toward you as your .* falls into the azurite bin')
+        bput("put #{item} in bin", 'nods toward you as your .* falls into the .* bin')
       else
         put("get #{item} from my #{@stealing_bag}")
         put("put #{item} in bin")
@@ -130,8 +140,6 @@ class Steal
       pause 0.25
     end
 
-    move('south')
-    move('go door')
   end
 
   def find_targets(item, container)
@@ -159,9 +167,27 @@ class Steal
       return nil if line =~ /^no/i
       break if line =~ /^yes/i
     end
+	
+	line = nil
+	first = 1
+	respond
+	respond('In what town is this shop located? ;send #')
+	respond
+	
+	for which in (first)..(@town_data.to_h.keys.length)
+	  respond "#{(which).to_s.rjust(5)}: #{@town_data.to_h.keys[which-1]}"
+	end
+	
+	loop do
+      line = get
+      return nil if line =~ /^no/i
+      break if line =~ /^[0-9]+$/i
+    end
+	
+	new_steal_town = "#{@town_data.to_h.keys[line.to_i-1]}"
 
     {
-      'new' => true, 'room' => Room.current.id, 'province' => 'zoluren',
+      'new' => true, 'room' => Room.current.id, 'steal_town' => new_steal_town,
       'item' => item, 'item_in' => container, 'pawnable' => false,
       'id' => @stealing_options.map { |x| x['id'].to_i }.max + 1
     }
@@ -320,6 +346,9 @@ class Steal
     in_message = target['item_in']
     waitrt?
     count += 1
+	if new_grab = true
+	  count = 5
+	end
     case bput("steal #{item} #{in_message}",
               'You learned exceptionally well from this nearly impossible theft',
               'You learned very well from this extremely difficult theft',


### PR DESCRIPTION
Selects stealing targets based on user's hometown selection in their yaml.

Changed the build_new function variable province to steal_town. The variable was static before and did not change. I did not find any place where the province variable was being utilized. Due to this change in granularity and variable name change, base-stealing.yaml would need to be updated with new values. I used find and replace to change all of the "province: zoluren" to "steal_town: Crossing" in the base-stealing.yaml.

Thief binning changed to walk_to the bin location pulled from base-town.yaml. Crossing is 9080 and Muspar'i is 12283 work. I don't know if the other locations are setup to work with go2 but that is another issue that can be worked out.

Due to the base-stealing.yaml daily update, a separate pull request will be made once steal.lic this merge is deemed ready to be merged. Here is an example: https://pastebin.com/gWDKKvPT